### PR TITLE
[Bug] Fix laser display orientation

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -274,9 +274,14 @@ class MBotApp extends React.Component {
 
     let rays = [];
     for(let i = 0; i < lidarLength; i++) {
+
+      //Lasers come in lidar frame (origin same as robot frame but + theta is CW)
+      //First tranform into robot frame
+      var theta = -1 * evt.thetas[i];
+      // console.log("Transformed ray theta");
       // Convert the ray into pixel coordinates.
-      let rayX = evt.ranges[i] * Math.cos(normalizeAngle(evt.thetas[i] + this.state.theta)) * this.state.pixelsPerMeter;
-      let rayY = evt.ranges[i] * Math.sin(normalizeAngle(evt.thetas[i] + this.state.theta)) * this.state.pixelsPerMeter;
+      let rayX = evt.ranges[i] * Math.cos(normalizeAngle(theta + this.state.theta)) * this.state.pixelsPerMeter;
+      let rayY = evt.ranges[i] * Math.sin(normalizeAngle(theta + this.state.theta)) * this.state.pixelsPerMeter;
       // Shift by the current robot position.
       rayX += this.state.x;
       rayY += this.state.y;

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -44,8 +44,8 @@ class GridCellCanvas {
     this.canvas = canvas;
 
     this.ctx = this.canvas.getContext('2d');
-    this.ctx.transform(1, 0, 0, -1, 0, 0);
-    this.ctx.transform(1, 0, 0, 1, 0, -this.canvas.width);
+    this.ctx.transform(1, 0, 0, -1, 0, 0); 
+    this.ctx.transform(1, 0, 0, 1, 0, -this.canvas.height);
 
     this.width = this.canvas.width;
     this.height = this.canvas.height;


### PR DESCRIPTION
Lidar readings come in the lidar frame. This PR transforms them to robot frame before calculating the cell at the end of the ray. Closes #45.

See the screenshot below for before:
![bad](https://user-images.githubusercontent.com/47364146/186493728-1f4693be-278e-479e-9cc0-c946ac3df314.png)


and after:
![good](https://user-images.githubusercontent.com/47364146/186493751-9cd705e0-6ddc-4b9b-b8a0-0dfdfe53549f.png)

